### PR TITLE
Removed the link to README and replaced it with the actual content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# NCBI C++ Toolkit
 
-[README](doc/public/README.md)
+### Download
+[Public Access to the Source Code via GitHub](https://ncbi.github.io/cxx-toolkit/pages/ch_getcode_svn#ch_getcode_svn.external)
+
+### Documentation
+[The NCBI C++ Toolkit Book](https://ncbi.github.io/cxx-toolkit/) 
+
+### Contact
+email: cpp-group@ncbi.nlm.nih.gov
+
 


### PR DESCRIPTION
README in the root directory of the repository should contain the actual info, not the link to it.