### PR TITLE
Add CSeqDB::SetMMapStrategy() for caller-controlled madvise on BLAST DB mmaps

### DIFF
--- a/include/corelib/ncbi_system.hpp
+++ b/include/corelib/ncbi_system.hpp
@@ -521,7 +521,9 @@ typedef enum {
     eMADV_DontFork,    ///< Don't inherit across fork()
     // Available since Linux kernel 2.6.32
     eMADV_Mergeable,   ///< KSM may merge identical pages
-    eMADV_Unmergeable  ///< KSM may not merge identical pages -- by default
+    eMADV_Unmergeable, ///< KSM may not merge identical pages -- by default
+    // Available since Linux kernel 2.4.20
+    eMADV_NoReuse      ///< Data will be accessed only once (MADV_NOREUSE)
 } EMemoryAdvise;
 
 

--- a/include/corelib/ncbifile.hpp
+++ b/include/corelib/ncbifile.hpp
@@ -2486,7 +2486,8 @@ public:
         eMMA_DoFork      = eMADV_DoFork,
         eMMA_DontFork    = eMADV_DontFork,
         eMMA_Mergeable   = eMADV_Mergeable,
-        eMMA_Unmergeable = eMADV_Unmergeable
+        eMMA_Unmergeable = eMADV_Unmergeable,
+        eMMA_NoReuse     = eMADV_NoReuse
     } EMemMapAdvise;
 
     /// Advise on memory map usage for specified region.

--- a/include/objtools/blast/seqdb_reader/impl/seqdbatlas.hpp
+++ b/include/objtools/blast/seqdb_reader/impl/seqdbatlas.hpp
@@ -536,6 +536,23 @@ public:
 
     CMemoryFile* GetMemoryFile(const string& fileName);
 
+    /// Set the memory mapping strategy for all memory-mapped BLAST DB files.
+    ///
+    /// This advises the operating system about the expected access pattern,
+    /// allowing it to optimize page cache behavior.  The default is
+    /// eMMA_Normal (OS-decided, typically with readahead enabled).
+    ///
+    /// This method applies the hint retroactively to already-opened files
+    /// and to all files opened subsequently.  Callers performing sparse
+    /// random lookups (e.g., fetching individual sequences by OID) may
+    /// benefit from eMMA_Random to disable readahead and reduce page cache
+    /// pollution.
+    ///
+    /// @param strategy
+    ///   The desired access pattern hint.
+    /// @sa CMemoryFile_Base::EMemMapAdvise
+    void SetMMapStrategy(CMemoryFile_Base::EMemMapAdvise strategy);
+
     enum EFilesCount{
         eFileCounterNoChange,
         eFileCounterIncrement,
@@ -568,7 +585,10 @@ private:
 
     class CAtlasMappedFile : public CMemoryFile {
     public:
-    	CAtlasMappedFile(const string & filename): CMemoryFile(filename),m_Count(1){
+    	CAtlasMappedFile(const string & filename,
+    	                EMemMapAdvise advise = eMMA_Normal)
+    		: CMemoryFile(filename), m_Count(1)
+    	{
     		const string exts="hd|hi|nd|ni|pd|pi|si|sd|ti|td";
     		string ext = filename.substr(filename.length()-2);
     		if (exts.find(ext) != NPOS) {
@@ -576,6 +596,9 @@ private:
     		}
     		else {
     			m_isIsam = false;
+    		}
+    		if (advise != eMMA_Normal) {
+    			MemMapAdvise(advise);
     		}
     	}
     	~CAtlasMappedFile() {
@@ -606,6 +629,9 @@ private:
     map<string, unique_ptr<CAtlasMappedFile> > m_FileMemMap;
     int m_OpenedFilesCount;
     int m_MaxOpenedFilesCount;
+
+    /// Memory mapping strategy for mmap'd files.
+    CMemoryFile_Base::EMemMapAdvise m_MMapStrategy;
 
     /// BlastDB search path.
     const string m_SearchPath;

--- a/include/objtools/blast/seqdb_reader/seqdb.hpp
+++ b/include/objtools/blast/seqdb_reader/seqdb.hpp
@@ -54,6 +54,7 @@
 #include <objects/blastdb/Blast_db_mask_info.hpp>
 #include <util/sequtil/sequtil.hpp>
 #include <util/range.hpp>
+#include <corelib/ncbifile.hpp>
 #include <set>
 #include <objmgr/bioseq_handle.hpp>
 
@@ -1531,6 +1532,24 @@ public:
     /// Get OIDs from an ID list
     /// @param id_list input id list/output oid found
     bool IdsToOids(CSeqDBGiList & id_list) const;
+
+    /// Set the memory mapping strategy for BLAST database files.
+    ///
+    /// This advises the operating system about the expected access pattern
+    /// for memory-mapped BLAST database files, allowing it to optimize
+    /// page cache behavior.  The default is eMMA_Normal (OS-decided,
+    /// typically with readahead enabled).
+    ///
+    /// This method applies the hint retroactively to already-opened files
+    /// and to all files opened subsequently.  Callers performing sparse
+    /// random lookups (e.g., fetching individual sequences by OID) may
+    /// benefit from eMMA_Random to disable readahead and reduce page cache
+    /// pollution.
+    ///
+    /// @param strategy
+    ///   The desired access pattern hint.
+    /// @sa CMemoryFile_Base::EMemMapAdvise
+    void SetMMapStrategy(CMemoryFile_Base::EMemMapAdvise strategy);
 
 protected:
     /// Implementation details are hidden.  (See seqdbimpl.hpp).

--- a/src/corelib/ncbi_system.cpp
+++ b/src/corelib/ncbi_system.cpp
@@ -1240,6 +1240,15 @@ bool MemoryAdvise(void* addr, size_t len, EMemoryAdvise advise)
             CNcbiError::Set(CNcbiError::eNotSupported);
             return false;
         #endif        
+    case eMADV_NoReuse:
+        #if defined(MADV_NOREUSE)
+            adv = MADV_NOREUSE;
+            break;
+        #else
+            ERR_POST_X_ONCE(12, Warning << "MADV_NOREUSE not supported");
+            CNcbiError::Set(CNcbiError::eNotSupported);
+            return false;
+        #endif        
     default:
         _TROUBLE;
         return false;

--- a/src/objtools/blast/seqdb_reader/seqdb.cpp
+++ b/src/objtools/blast/seqdb_reader/seqdb.cpp
@@ -1775,5 +1775,11 @@ bool CSeqDB::IdsToOids(CSeqDBGiList & id_list) const
 }
 
 
+void CSeqDB::SetMMapStrategy(CMemoryFile_Base::EMemMapAdvise strategy)
+{
+    m_Impl->SetMMapStrategy(strategy);
+}
+
+
 END_NCBI_SCOPE
 

--- a/src/objtools/blast/seqdb_reader/seqdbatlas.cpp
+++ b/src/objtools/blast/seqdb_reader/seqdbatlas.cpp
@@ -101,7 +101,8 @@ TOut SeqDB_CheckLength(TIn value)
 CSeqDBAtlas::CSeqDBAtlas(bool use_atlas_lock)
      :m_UseLock           (use_atlas_lock),
       m_MaxFileSize       (0),      
-      m_SearchPath        (GenerateSearchPath())
+      m_SearchPath        (GenerateSearchPath()),
+      m_MMapStrategy      (CMemoryFile_Base::eMMA_Normal)
 {
     m_OpenedFilesCount = 0;
     m_MaxOpenedFilesCount = 0;
@@ -120,11 +121,20 @@ CMemoryFile* CSeqDBAtlas::GetMemoryFile(const string& fileName)
     	//LOG_POST(Info << "File: " << fileName << " count " << it->second.get()->m_Count);
         return it->second.get();
     }
-    CAtlasMappedFile* file(new CAtlasMappedFile(fileName));
+    CAtlasMappedFile* file(new CAtlasMappedFile(fileName, m_MMapStrategy));
     m_FileMemMap[fileName].reset(file);
    	_TRACE("Open File: " << fileName);
     ChangeOpenedFilseCount(CSeqDBAtlas::eFileCounterIncrement);
     return file;
+}
+
+void CSeqDBAtlas::SetMMapStrategy(CMemoryFile_Base::EMemMapAdvise strategy)
+{
+    std::lock_guard<std::mutex> guard(m_FileMemMapMutex);
+    m_MMapStrategy = strategy;
+    for (auto& kv : m_FileMemMap) {
+        kv.second->MemMapAdvise(strategy);
+    }
 }
 
 CMemoryFile* CSeqDBAtlas::ReturnMemoryFile(const string& fileName)

--- a/src/objtools/blast/seqdb_reader/seqdbimpl.hpp
+++ b/src/objtools/blast/seqdb_reader/seqdbimpl.hpp
@@ -1056,6 +1056,13 @@ public:
     ///                 internal mmap. [in]
     void SetNumberOfThreads(int num_threads, bool force_mt = false);
 
+    /// Set the memory mapping strategy for BLAST DB files.
+    /// @param strategy The desired access pattern hint.
+    void SetMMapStrategy(CMemoryFile_Base::EMemMapAdvise strategy)
+    {
+        m_Atlas.SetMMapStrategy(strategy);
+    }
+
     /// Set the membership bit of all volumes
     void SetVolsMemBit(int mbit);
 


### PR DESCRIPTION
CSeqDB's internal CAtlasMappedFile uses default madvise (readahead), which is optimal for sequential scans like BLAST+ but causes page cache pollution for applications that perform sparse random lookups by OID.

This adds a public SetMMapStrategy() method that lets callers specify the desired madvise hint (Normal, Random, Sequential, NoReuse, etc.) for memory-mapped BLAST DB files.  The method applies retroactively to already-opened files and to all files opened subsequently.  The default remains eMMA_Normal (no behavior change for existing code).

Changes:
- corelib: add eMADV_NoReuse / eMMA_NoReuse (maps to MADV_NOREUSE)
- CSeqDBAtlas: store per-atlas madvise strategy, pass to CAtlasMappedFile
- CSeqDB public API: SetMMapStrategy() forwarded through CSeqDBImpl

Usage:
  CSeqDB db("nt", CSeqDB::eNucleotide);
  db.SetMMapStrategy(CMemoryFile_Base::eMMA_Random);